### PR TITLE
Adding New Experience previewing Overlay

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,7 +29,7 @@ const Navbar = ({ save, toggle }) => (
             </Link>
           </NavButton>
           <NavButton key="toggle" onClick={toggle}>
-            Hide/Show Bars
+            Toggle Preview Mode
           </NavButton>
           <NavButton key="save" onClick={save}>
             Save

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -110,15 +110,13 @@ function Overlay({ userId, experienceData }): JSX.Element {
       </NavbarDiv>
       {showOverlay ? (
         <OverlayShown
-          className={showOverlay ? styles.visible : styles.invisible}
+          className={swapOverlayStyles()}
         >
           <OverlayGrid>
             <OverlayGridItem1>
               <ApparatusListBox
                 metadata={
-                  experienceData !== undefined
-                    ? experienceData.apparatusMetadata
-                    : undefined
+                  checkIfMetaExists()
                 }
                 handleAssetBundleChange={(data) => setAssetbundle(data)}
               />
@@ -153,5 +151,15 @@ function Overlay({ userId, experienceData }): JSX.Element {
       )}
     </OverlayRoot>
   );
+
+  function checkIfMetaExists(): any {
+    return experienceData !== undefined
+      ? experienceData.apparatusMetadata
+      : undefined;
+  }
+
+  function swapOverlayStyles(): string {
+    return showOverlay ? styles.visible : styles.invisible;
+  }
 }
 export default Overlay;

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -148,7 +148,7 @@ function Overlay({ userId, experienceData }): JSX.Element {
         </OverlayShown>
       ) : (
         <OverlayShown>
-          <PreviewOverlay userId={userId} experienceData={experienceData} />
+          <PreviewOverlay userId={userId} experienceData={experienceData} actionList = {actionList} />
         </OverlayShown>
       )}
     </OverlayRoot>

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -148,7 +148,7 @@ function Overlay({ userId, experienceData }): JSX.Element {
         </OverlayShown>
       ) : (
         <OverlayShown>
-          <PreviewOverlay userId={userId} experienceData={experienceData} actionList = {actionList} />
+          <PreviewOverlay actionList = {actionList} />
         </OverlayShown>
       )}
     </OverlayRoot>

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../util/overlayfunc/overlayfunc";
 import saveExperienceToCloud from "../../util/saveExperienceToCloud";
 import Navbar from "../Navbar";
+import PreviewOverlay from "../previewOverlay/PreviewOverlay";
 import styles from "../../styles/NavbarStyle.module.css";
 
 const OverlayRoot = styled.div`
@@ -70,7 +71,7 @@ const NavbarDiv = styled.div`
 `;
 
 function Overlay({ userId, experienceData }): JSX.Element {
-  const [assetbundle, setAssetbundle] = useState({identifier:[]});
+  const [assetbundle, setAssetbundle] = useState({ identifier: [] });
   const [showOverlay, setOverlay] = useState(false);
   const [actionList, setActionList] = useState(
     experienceData !== undefined
@@ -107,41 +108,49 @@ function Overlay({ userId, experienceData }): JSX.Element {
           toggle={toggleOverlay}
         />
       </NavbarDiv>
-      <OverlayShown className={showOverlay ? styles.visible : styles.invisible}>
-        <OverlayGrid>
-          <OverlayGridItem1>
-            <ApparatusListBox
-              metadata={
-                experienceData !== undefined
-                  ? experienceData.apparatusMetadata
-                  : undefined
-              }
-              handleAssetBundleChange={(data) => setAssetbundle(data)}
-            />
-          </OverlayGridItem1>
-          <OverlayGridItem2>
-            <ActionSequenceBox
-              actionList={actionList}
-              removeAction={(index) =>
-                removeActionFromList(index, actionList, setActionList)
-              }
-              handleOnDragEnd={handleOnDragEnd}
-            />
-          </OverlayGridItem2>
-          <OverlayGridItem3>
-            <ActionBox
-              assetbundle={assetbundle}
-              addAction={([path, input]) =>
-                addActionToList(
-                  [path, input, assetbundle.identifier[0]],
-                  actionList,
-                  setActionList
-                )
-              }
-            />
-          </OverlayGridItem3>
-        </OverlayGrid>
-      </OverlayShown>
+      {showOverlay ? (
+        <OverlayShown
+          className={showOverlay ? styles.visible : styles.invisible}
+        >
+          <OverlayGrid>
+            <OverlayGridItem1>
+              <ApparatusListBox
+                metadata={
+                  experienceData !== undefined
+                    ? experienceData.apparatusMetadata
+                    : undefined
+                }
+                handleAssetBundleChange={(data) => setAssetbundle(data)}
+              />
+            </OverlayGridItem1>
+            <OverlayGridItem2>
+              <ActionSequenceBox
+                actionList={actionList}
+                removeAction={(index) =>
+                  removeActionFromList(index, actionList, setActionList)
+                }
+                handleOnDragEnd={handleOnDragEnd}
+              />
+            </OverlayGridItem2>
+            <OverlayGridItem3>
+              <ActionBox
+                assetbundle={assetbundle}
+                addAction={([path, input]) =>
+                  addActionToList(
+                    [path, input, assetbundle.identifier[0]],
+                    actionList,
+                    setActionList
+                  )
+                }
+              />
+            </OverlayGridItem3>
+          </OverlayGrid>
+        </OverlayShown>
+      ) : (
+        <OverlayShown>
+          <PreviewOverlay userId={userId} experienceData={experienceData} />
+        </OverlayShown>
+      )}
     </OverlayRoot>
   );
 }

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -72,7 +72,7 @@ const NavbarDiv = styled.div`
 
 function Overlay({ userId, experienceData }): JSX.Element {
   const [assetbundle, setAssetbundle] = useState({ identifier: [] });
-  const [showOverlay, setOverlay] = useState(false);
+  const [showOverlay, setOverlay] = useState(true);
   const [actionList, setActionList] = useState(
     experienceData !== undefined
       ? experienceData.initializationData.actionList

--- a/src/components/previewOverlay/PreviewOverlay.tsx
+++ b/src/components/previewOverlay/PreviewOverlay.tsx
@@ -91,13 +91,12 @@ function PreviewOverlay({actionList}): JSX.Element {
               outlineWidth: "0.1em",
               outlineColor: "black",
             }}
+            onClick={selected > 0 ? ()=>{setCount(selected - 1); callToWebGL(actionList[selected-1][0], actionList[selected-1][1]) } :undefined}
           >
-            <ChevronLeftSharpIcon onClick={selected > 0 ? ()=>{setCount(selected - 1); callToWebGL(actionList[selected][0], actionList[selected][1]) } :undefined} />
+            <ChevronLeftSharpIcon  />
           </IconButton>
         </PreviewGridLeft>
-       
         <PreviewGridCenter>
-          {selected}
           <ActionTabList>
             {actionList.map((data, index) => (  
             <ActionTabListItem key={index}>
@@ -117,8 +116,9 @@ function PreviewOverlay({actionList}): JSX.Element {
               outlineWidth: "0.1em",
               outlineColor: "black",
             }}
+            onClick={ selected < actionList.length-1 ? ()=>{setCount(selected + 1) ; callToWebGL(actionList[selected+1][0], actionList[selected+1][1]) } :undefined}
           >
-            <ChevronRightSharpIcon onClick={ selected <= actionList.length-1 ? ()=>{setCount(selected + 1) ; callToWebGL(actionList[selected][0], actionList[selected][1]) } :undefined} />
+            <ChevronRightSharpIcon  />
           </IconButton>
         </PreviewGridRight>
         

--- a/src/components/previewOverlay/PreviewOverlay.tsx
+++ b/src/components/previewOverlay/PreviewOverlay.tsx
@@ -53,7 +53,7 @@ const PreviewGridRight = styled.div`
 const ActionTabList = styled.div`
   display: flex;
   overflow-x: scroll;
-
+  align-items: center;
 `;
 const ActionTabListItem = styled.div`
   min-height: 1em;
@@ -61,9 +61,10 @@ const ActionTabListItem = styled.div`
   outline-width: 0.1em;
   outline-color: black;
   margin: 1em;
+  align-self: center;
 `;
 
-function PreviewOverlay({ userId, experienceData }): JSX.Element {
+function PreviewOverlay({ userId, experienceData ,actionList}): JSX.Element {
   return (
     <PreviewRoot>
       <PreviewGrid>
@@ -82,33 +83,9 @@ function PreviewOverlay({ userId, experienceData }): JSX.Element {
         </PreviewGridLeft>
         <PreviewGridCenter>
           <ActionTabList>
-            <ActionTabListItem>
-              <Button>1</Button>
-            </ActionTabListItem>
-            <ActionTabListItem>
-              <Button>2</Button>
-            </ActionTabListItem>
-            <ActionTabListItem>
-              <Button>3</Button>
-            </ActionTabListItem>
-            <ActionTabListItem>
-              <Button>4</Button>
-            </ActionTabListItem>
-            <ActionTabListItem>
-              <Button>5</Button>
-            </ActionTabListItem>
-            <ActionTabListItem>
-              <Button>6</Button>
-            </ActionTabListItem>
-            <ActionTabListItem>
-              <Button>7</Button>
-            </ActionTabListItem>
-            <ActionTabListItem>
-              <Button>8</Button>
-            </ActionTabListItem>
-            <ActionTabListItem>
-              <Button>9</Button>
-            </ActionTabListItem>
+            {actionList.map((data, index) => (<ActionTabListItem key={index}>
+              <Button>{index}</Button>
+            </ActionTabListItem>))}
           </ActionTabList>
         </PreviewGridCenter>
         <PreviewGridRight>

--- a/src/components/previewOverlay/PreviewOverlay.tsx
+++ b/src/components/previewOverlay/PreviewOverlay.tsx
@@ -1,9 +1,12 @@
 import styled from "styled-components";
+import ChevronLeftSharpIcon from "@mui/icons-material/ChevronLeftSharp";
+import ChevronRightSharpIcon from "@mui/icons-material/ChevronRightSharp";
+import { Button, IconButton } from "@material-ui/core";
 
 const PreviewRoot = styled.div`
   display: absolute;
   width: inherit;
-  height: 850px;
+  height: 900px;
   opacity: 1;
   pointer-events: auto;
 `;
@@ -12,49 +15,115 @@ const PreviewGrid = styled.div`
   width: inherit;
   height: inherit;
   grid-template-columns: repeat(19, 1fr);
-  grid-template-rows: repeat(9, 1fr);
+  grid-template-rows: repeat(15, 1fr);
 `;
 
 const PreviewGridLeft = styled.div`
-  background-color: #1b791b;
   grid-column: 5 / span 1;
-  grid-row: 10 / span 1;
+  grid-row: 14 / span 1;
   z-index: 2;
   pointer-events: auto;
   margin: 5%;
-  min-height: 3em;
+  min-height: 2em;
   min-width: 2em;
 `;
 
 const PreviewGridCenter = styled.div`
-  background-color: #814e8b;
-  grid-column: 7 / span 7 ;
-  grid-row: 10 / span 1;
+  grid-column: 7 / span 7;
+  grid-row: 13 / span 1;
   z-index: 2;
   pointer-events: auto;
   margin: 5%;
-  min-height: 3em;
+  min-height: 1em;
   min-width: inherit;
+  padding-left: 10%;
+  padding-right: 10%;
 `;
 
 const PreviewGridRight = styled.div`
-  background-color: #4e578b;
   grid-column: 15 / span 1;
-  grid-row: 10 / span 1;
+  grid-row: 14 / span 1;
   z-index: 2;
   pointer-events: auto;
   margin: 5%;
-  min-height: 3em;
+  min-height: 2em;
   min-width: 2em;
+`;
+
+const ActionTabList = styled.div`
+  display: flex;
+  overflow-x: scroll;
+
+`;
+const ActionTabListItem = styled.div`
+  min-height: 1em;
+  outline-style: solid;
+  outline-width: 0.1em;
+  outline-color: black;
+  margin: 1em;
 `;
 
 function PreviewOverlay({ userId, experienceData }): JSX.Element {
   return (
     <PreviewRoot>
       <PreviewGrid>
-        <PreviewGridLeft/>
-        <PreviewGridCenter/>
-        <PreviewGridRight/>
+        <PreviewGridLeft>
+          <IconButton
+            style={{
+              minWidth: "100%",
+              minHeight: "100%",
+              outlineStyle: "solid",
+              outlineWidth: "0.1em",
+              outlineColor: "black",
+            }}
+          >
+            <ChevronLeftSharpIcon />
+          </IconButton>
+        </PreviewGridLeft>
+        <PreviewGridCenter>
+          <ActionTabList>
+            <ActionTabListItem>
+              <Button>1</Button>
+            </ActionTabListItem>
+            <ActionTabListItem>
+              <Button>2</Button>
+            </ActionTabListItem>
+            <ActionTabListItem>
+              <Button>3</Button>
+            </ActionTabListItem>
+            <ActionTabListItem>
+              <Button>4</Button>
+            </ActionTabListItem>
+            <ActionTabListItem>
+              <Button>5</Button>
+            </ActionTabListItem>
+            <ActionTabListItem>
+              <Button>6</Button>
+            </ActionTabListItem>
+            <ActionTabListItem>
+              <Button>7</Button>
+            </ActionTabListItem>
+            <ActionTabListItem>
+              <Button>8</Button>
+            </ActionTabListItem>
+            <ActionTabListItem>
+              <Button>9</Button>
+            </ActionTabListItem>
+          </ActionTabList>
+        </PreviewGridCenter>
+        <PreviewGridRight>
+          <IconButton
+            style={{
+              minWidth: "100%",
+              minHeight: "100%",
+              outlineStyle: "solid",
+              outlineWidth: "0.1em",
+              outlineColor: "black",
+            }}
+          >
+            <ChevronRightSharpIcon />
+          </IconButton>
+        </PreviewGridRight>
       </PreviewGrid>
     </PreviewRoot>
   );

--- a/src/components/previewOverlay/PreviewOverlay.tsx
+++ b/src/components/previewOverlay/PreviewOverlay.tsx
@@ -1,0 +1,63 @@
+import styled from "styled-components";
+
+const PreviewRoot = styled.div`
+  display: absolute;
+  width: inherit;
+  height: 850px;
+  opacity: 1;
+  pointer-events: auto;
+`;
+const PreviewGrid = styled.div`
+  display: grid;
+  width: inherit;
+  height: inherit;
+  grid-template-columns: repeat(19, 1fr);
+  grid-template-rows: repeat(9, 1fr);
+`;
+
+const PreviewGridLeft = styled.div`
+  background-color: #1b791b;
+  grid-column: 5 / span 1;
+  grid-row: 10 / span 1;
+  z-index: 2;
+  pointer-events: auto;
+  margin: 5%;
+  min-height: 3em;
+  min-width: 2em;
+`;
+
+const PreviewGridCenter = styled.div`
+  background-color: #814e8b;
+  grid-column: 7 / span 7 ;
+  grid-row: 10 / span 1;
+  z-index: 2;
+  pointer-events: auto;
+  margin: 5%;
+  min-height: 3em;
+  min-width: inherit;
+`;
+
+const PreviewGridRight = styled.div`
+  background-color: #4e578b;
+  grid-column: 15 / span 1;
+  grid-row: 10 / span 1;
+  z-index: 2;
+  pointer-events: auto;
+  margin: 5%;
+  min-height: 3em;
+  min-width: 2em;
+`;
+
+function PreviewOverlay({ userId, experienceData }): JSX.Element {
+  return (
+    <PreviewRoot>
+      <PreviewGrid>
+        <PreviewGridLeft/>
+        <PreviewGridCenter/>
+        <PreviewGridRight/>
+      </PreviewGrid>
+    </PreviewRoot>
+  );
+}
+
+export default PreviewOverlay;

--- a/src/components/previewOverlay/PreviewOverlay.tsx
+++ b/src/components/previewOverlay/PreviewOverlay.tsx
@@ -91,7 +91,7 @@ function PreviewOverlay({actionList}): JSX.Element {
               outlineWidth: "0.1em",
               outlineColor: "black",
             }}
-            onClick={selected > 0 ? ()=>{setCount(selected - 1); callToWebGL(actionList[selected-1][0], actionList[selected-1][1]) } :undefined}
+            onClick={cyclePreviewLeft()}
           >
             <ChevronLeftSharpIcon  />
           </IconButton>
@@ -116,7 +116,7 @@ function PreviewOverlay({actionList}): JSX.Element {
               outlineWidth: "0.1em",
               outlineColor: "black",
             }}
-            onClick={ selected < actionList.length-1 ? ()=>{setCount(selected + 1) ; callToWebGL(actionList[selected+1][0], actionList[selected+1][1]) } :undefined}
+            onClick={ cyclePreviewRight()}
           >
             <ChevronRightSharpIcon  />
           </IconButton>
@@ -126,6 +126,14 @@ function PreviewOverlay({actionList}): JSX.Element {
       : <div/>}
     </PreviewRoot>
   );
+
+  function cyclePreviewRight() {
+    return selected < actionList.length - 1 ? () => { setCount(selected + 1); callToWebGL(actionList[selected + 1][0], actionList[selected + 1][1]); } : undefined;
+  }
+
+  function cyclePreviewLeft() {
+    return selected > 0 ? () => { setCount(selected - 1); callToWebGL(actionList[selected - 1][0], actionList[selected - 1][1]); } : undefined;
+  }
 }
 
 export default PreviewOverlay;

--- a/src/components/previewOverlay/PreviewOverlay.tsx
+++ b/src/components/previewOverlay/PreviewOverlay.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import ChevronLeftSharpIcon from "@mui/icons-material/ChevronLeftSharp";
 import ChevronRightSharpIcon from "@mui/icons-material/ChevronRightSharp";
 import { Button, IconButton } from "@material-ui/core";
+import { callToWebGL } from "../../util/unityContextActions";
 
 const PreviewRoot = styled.div`
   display: absolute;
@@ -84,7 +85,7 @@ function PreviewOverlay({ userId, experienceData ,actionList}): JSX.Element {
         <PreviewGridCenter>
           <ActionTabList>
             {actionList.map((data, index) => (<ActionTabListItem key={index}>
-              <Button>{index}</Button>
+              <Button onClick={() => callToWebGL(data[0], data[1])}>{index}</Button>
             </ActionTabListItem>))}
           </ActionTabList>
         </PreviewGridCenter>

--- a/src/components/previewOverlay/PreviewOverlay.tsx
+++ b/src/components/previewOverlay/PreviewOverlay.tsx
@@ -3,6 +3,7 @@ import ChevronLeftSharpIcon from "@mui/icons-material/ChevronLeftSharp";
 import ChevronRightSharpIcon from "@mui/icons-material/ChevronRightSharp";
 import { Button, IconButton } from "@material-ui/core";
 import { callToWebGL } from "../../util/unityContextActions";
+import { useState } from "react";
 
 const PreviewRoot = styled.div`
   display: absolute;
@@ -65,9 +66,21 @@ const ActionTabListItem = styled.div`
   align-self: center;
 `;
 
-function PreviewOverlay({ userId, experienceData ,actionList}): JSX.Element {
+const ActionTabSelectedListItem = styled.div`
+background-color: white;
+`;
+
+function PreviewOverlay({actionList}): JSX.Element {
+
+  const [selected, setCount] = useState(0);
+
+
+
+
   return (
     <PreviewRoot>
+      
+      {actionList[0] !== undefined ? 
       <PreviewGrid>
         <PreviewGridLeft>
           <IconButton
@@ -79,17 +92,22 @@ function PreviewOverlay({ userId, experienceData ,actionList}): JSX.Element {
               outlineColor: "black",
             }}
           >
-            <ChevronLeftSharpIcon />
+            <ChevronLeftSharpIcon onClick={selected > 0 ? ()=>{setCount(selected - 1); callToWebGL(actionList[selected][0], actionList[selected][1]) } :undefined} />
           </IconButton>
         </PreviewGridLeft>
-        {actionList[0] !== undefined ? 
+       
         <PreviewGridCenter>
+          {selected}
           <ActionTabList>
-            {actionList.map((data, index) => (<ActionTabListItem key={index}>
-              <Button onClick={() => callToWebGL(data[0], data[1])}>{index}</Button>
-            </ActionTabListItem>))}
+            {actionList.map((data, index) => (  
+            <ActionTabListItem key={index}>
+              {selected===index ? <ActionTabSelectedListItem>
+                <Button onClick={() => {callToWebGL(data[0], data[1]); setCount(index)}}>{index}</Button>
+              </ActionTabSelectedListItem>:<Button onClick={() => {callToWebGL(data[0], data[1]); setCount(index)}}>{index}</Button>}
+            </ActionTabListItem>   
+            ))}
           </ActionTabList>
-        </PreviewGridCenter> : <div/>}
+        </PreviewGridCenter> 
         <PreviewGridRight>
           <IconButton
             style={{
@@ -100,10 +118,12 @@ function PreviewOverlay({ userId, experienceData ,actionList}): JSX.Element {
               outlineColor: "black",
             }}
           >
-            <ChevronRightSharpIcon />
+            <ChevronRightSharpIcon onClick={ selected <= actionList.length-1 ? ()=>{setCount(selected + 1) ; callToWebGL(actionList[selected][0], actionList[selected][1]) } :undefined} />
           </IconButton>
         </PreviewGridRight>
+        
       </PreviewGrid>
+      : <div/>}
     </PreviewRoot>
   );
 }

--- a/src/components/previewOverlay/PreviewOverlay.tsx
+++ b/src/components/previewOverlay/PreviewOverlay.tsx
@@ -82,13 +82,14 @@ function PreviewOverlay({ userId, experienceData ,actionList}): JSX.Element {
             <ChevronLeftSharpIcon />
           </IconButton>
         </PreviewGridLeft>
+        {actionList[0] !== undefined ? 
         <PreviewGridCenter>
           <ActionTabList>
             {actionList.map((data, index) => (<ActionTabListItem key={index}>
               <Button onClick={() => callToWebGL(data[0], data[1])}>{index}</Button>
             </ActionTabListItem>))}
           </ActionTabList>
-        </PreviewGridCenter>
+        </PreviewGridCenter> : <div/>}
         <PreviewGridRight>
           <IconButton
             style={{


### PR DESCRIPTION
### Summary 
This PR implements the ability to preview actions through a toggle-able preview overlay.
### Details
1. Adds a new preview overlay to the navbar 
2. Overlay is toggle-able with the Preview Overlay
3. Preview Overlay allows users to traverse different actions from a saved sequence of actions (save button MUST be pressed)
### How to test?
1. spin up the app
2. select an apparatus 
3. Select a sequence of actions and save in the overlay
4. Select "Toggle Preview" to bring up the preview overlay
5. use the left and right arrows to see if the sequence matches the saved ones
### Checks 
- [ ] Tested Changes
- [ ] Stakeholder Approval
