### PR TITLE
Overhaul of Props Drilling into Global Context Hooks

### DIFF
--- a/pages/experience.tsx
+++ b/pages/experience.tsx
@@ -12,8 +12,9 @@ import {
   getApparatusFromCloud,
   getExperienceFromCloud,
 } from "../src/util/cloudOperations/readFromCloud";
-import { ExperienceData } from "../src/util/types";
+import { ActionData, ExperienceData } from "../src/util/types";
 import Loading from "../src/components/Loading";
+import { useActionList } from "../src/util/customHooks/overlayfunc";
 
 const Content = styled.div`
   width: 100%;
@@ -29,10 +30,24 @@ type ExperienceProps = {
   dataType: string;
 };
 
-export const TestContext = createContext(null);
-
+export const TestContext = createContext(null);       // todo : delete after demo
 
 export const GlobalContext = createContext(null);
+
+ // make a type for typescript
+export type globalContextTypes = {
+  experienceData: ExperienceData;
+  setExperienceData: React.Dispatch<React.SetStateAction<ExperienceData>>;
+  selectedAction: number;
+  actionList: ActionData[];
+  removeActionFromList: (index: number) => void;
+  setDescription: (description: string) => void;
+  handleOnDragEnd: (result: {
+    destination: { index: number };
+    source: { index: number };
+  }) => void;
+  addActionToList: (actionData: ActionData) => void;
+};
 
 function Experience({
   apparatusId,
@@ -44,13 +59,18 @@ function Experience({
   const [userId] = useState(getUserName());
   const [experienceData, setExperienceData] = useState<ExperienceData>();
 
+  const {
+    selectedAction,
+    actionList,
+    removeActionFromList,
+    setDescription,
+    handleOnDragEnd,
+    addActionToList,
+  } = useActionList(experienceData);
 
   // experience data defined here - JUSTIN
-  // const ExperienceContext = React.createContext([experienceData, setExperienceData]);
-
-
   // test context
-  const [name, setName] = useState('INITIAL NAME');
+  const [name, setName] = useState("INITIAL NAME");
   const [price, setPrice] = useState(0);
 
   const testvalue = {
@@ -60,27 +80,19 @@ function Experience({
     setPrice,
   };
 
-  
-  
-
-  // make a type for typescript
-  type globalContextTypes = {
-    experienceData: ExperienceData;
-    setExperienceData: React.Dispatch<React.SetStateAction<ExperienceData>>;
-  }
+ 
 
   // All Global Context Hooks
   const globalContextValues: globalContextTypes = {
     experienceData,
     setExperienceData,
-  }
-
-
-
-
-
-
-
+    selectedAction,
+    actionList,
+    removeActionFromList,
+    setDescription,
+    handleOnDragEnd,
+    addActionToList,
+  };
 
   const experienceDataTemp: ExperienceData = {
     apparatusMetadata: { Id: "", Paths: [], Data: [] },
@@ -126,9 +138,9 @@ function Experience({
         <main>
           <Content>
             <TestContext.Provider value={testvalue}>
-            <GlobalContext.Provider value={globalContextValues}>                                                                                                          
-            <WebglBox userId={userId}  />
-            </GlobalContext.Provider>
+              <GlobalContext.Provider value={globalContextValues}>
+                <WebglBox userId={userId} />
+              </GlobalContext.Provider>
             </TestContext.Provider>
           </Content>
         </main>
@@ -152,5 +164,3 @@ Experience.getInitialProps = ({ query }) => {
 };
 
 export default Experience;
-
-

--- a/pages/experience.tsx
+++ b/pages/experience.tsx
@@ -30,11 +30,9 @@ type ExperienceProps = {
   dataType: string;
 };
 
-export const TestContext = createContext(null); // todo : delete after demo
-
 export const GlobalContext = createContext(null);
 
-// make a type for typescript
+// type for Context Values
 export type globalContextTypes = {
   experienceData: ExperienceData;
   setExperienceData: React.Dispatch<React.SetStateAction<ExperienceData>>;
@@ -47,7 +45,7 @@ export type globalContextTypes = {
     source: { index: number };
   }) => void;
   addActionToList: (actionData: ActionData) => void;
-  userId: string
+  userId: string;
 };
 
 function Experience({
@@ -69,18 +67,6 @@ function Experience({
     addActionToList,
   } = useActionList(experienceData);
 
-  // experience data defined here - JUSTIN
-  // test context
-  const [name, setName] = useState("INITIAL NAME");
-  const [price, setPrice] = useState(0);
-
-  const testvalue = {
-    name,
-    setName,
-    price,
-    setPrice,
-  };
-
   // All Global Context Hooks
   const globalContextValues: globalContextTypes = {
     experienceData,
@@ -91,7 +77,7 @@ function Experience({
     setDescription,
     handleOnDragEnd,
     addActionToList,
-    userId
+    userId,
   };
 
   const experienceDataTemp: ExperienceData = {
@@ -137,11 +123,9 @@ function Experience({
       return (
         <main>
           <Content>
-            <TestContext.Provider value={testvalue}>
-              <GlobalContext.Provider value={globalContextValues}>
-                <WebglBox userId={userId} />
-              </GlobalContext.Provider>
-            </TestContext.Provider>
+            <GlobalContext.Provider value={globalContextValues}>
+              <WebglBox userId={userId} />
+            </GlobalContext.Provider>
           </Content>
         </main>
       );

--- a/pages/experience.tsx
+++ b/pages/experience.tsx
@@ -65,7 +65,7 @@ function Experience({
     setDescription,
     handleOnDragEnd,
     addActionToList,
-  } = useActionList(experienceData);
+  } = useActionList(experienceData, setExperienceData);
 
   // All Global Context Hooks
   const globalContextValues: globalContextTypes = {
@@ -124,7 +124,7 @@ function Experience({
         <main>
           <Content>
             <GlobalContext.Provider value={globalContextValues}>
-              <WebglBox userId={userId} />
+              <WebglBox/>
             </GlobalContext.Provider>
           </Content>
         </main>

--- a/pages/experience.tsx
+++ b/pages/experience.tsx
@@ -31,6 +31,9 @@ type ExperienceProps = {
 
 export const TestContext = createContext(null);
 
+
+export const GlobalContext = createContext(null);
+
 function Experience({
   apparatusId,
   experienceId,
@@ -45,6 +48,8 @@ function Experience({
   // experience data defined here - JUSTIN
   // const ExperienceContext = React.createContext([experienceData, setExperienceData]);
 
+
+  // test context
   const [name, setName] = useState('INITIAL NAME');
   const [price, setPrice] = useState(0);
 
@@ -54,6 +59,28 @@ function Experience({
     price,
     setPrice,
   };
+
+  
+  
+
+  // make a type for typescript
+  type globalContextTypes = {
+    experienceData: ExperienceData;
+    setExperienceData: React.Dispatch<React.SetStateAction<ExperienceData>>;
+  }
+
+  // All Global Context Hooks
+  const globalContextValues: globalContextTypes = {
+    experienceData,
+    setExperienceData,
+  }
+
+
+
+
+
+
+
 
   const experienceDataTemp: ExperienceData = {
     apparatusMetadata: { Id: "", Paths: [], Data: [] },
@@ -98,8 +125,10 @@ function Experience({
       return (
         <main>
           <Content>
-            <TestContext.Provider value={testvalue}>                                                     
-            <WebglBox userId={userId} experienceData={experienceData} />
+            <TestContext.Provider value={testvalue}>
+            <GlobalContext.Provider value={globalContextValues}>                                                                                                          
+            <WebglBox userId={userId}  />
+            </GlobalContext.Provider>
             </TestContext.Provider>
           </Content>
         </main>

--- a/pages/experience.tsx
+++ b/pages/experience.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-arrow-callback */
 import styled from "styled-components";
-import React, { useState } from "react";
+import React, { createContext, useState } from "react";
 import { Alert, AlertTitle } from "@mui/material";
 import WebglBox from "../src/components/WebglBox";
 import {
@@ -29,6 +29,8 @@ type ExperienceProps = {
   dataType: string;
 };
 
+export const TestContext = createContext(null);
+
 function Experience({
   apparatusId,
   experienceId,
@@ -38,6 +40,20 @@ function Experience({
   const [error, setError] = useState("");
   const [userId] = useState(getUserName());
   const [experienceData, setExperienceData] = useState<ExperienceData>();
+
+
+  // experience data defined here - JUSTIN
+  // const ExperienceContext = React.createContext([experienceData, setExperienceData]);
+
+  const [name, setName] = useState('INITIAL NAME');
+  const [price, setPrice] = useState(0);
+
+  const testvalue = {
+    name,
+    setName,
+    price,
+    setPrice,
+  };
 
   const experienceDataTemp: ExperienceData = {
     apparatusMetadata: { Id: "", Paths: [], Data: [] },
@@ -82,7 +98,9 @@ function Experience({
       return (
         <main>
           <Content>
+            <TestContext.Provider value={testvalue}>                                                     
             <WebglBox userId={userId} experienceData={experienceData} />
+            </TestContext.Provider>
           </Content>
         </main>
       );
@@ -105,3 +123,5 @@ Experience.getInitialProps = ({ query }) => {
 };
 
 export default Experience;
+
+

--- a/pages/experience.tsx
+++ b/pages/experience.tsx
@@ -47,6 +47,7 @@ export type globalContextTypes = {
     source: { index: number };
   }) => void;
   addActionToList: (actionData: ActionData) => void;
+  userId: string
 };
 
 function Experience({
@@ -90,6 +91,7 @@ function Experience({
     setDescription,
     handleOnDragEnd,
     addActionToList,
+    userId
   };
 
   const experienceDataTemp: ExperienceData = {

--- a/pages/experience.tsx
+++ b/pages/experience.tsx
@@ -30,11 +30,11 @@ type ExperienceProps = {
   dataType: string;
 };
 
-export const TestContext = createContext(null);       // todo : delete after demo
+export const TestContext = createContext(null); // todo : delete after demo
 
 export const GlobalContext = createContext(null);
 
- // make a type for typescript
+// make a type for typescript
 export type globalContextTypes = {
   experienceData: ExperienceData;
   setExperienceData: React.Dispatch<React.SetStateAction<ExperienceData>>;
@@ -79,8 +79,6 @@ function Experience({
     price,
     setPrice,
   };
-
- 
 
   // All Global Context Hooks
   const globalContextValues: globalContextTypes = {

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -93,9 +93,7 @@ function Overlay({ userId, experienceData }: OverlayProps): JSX.Element {
   const {
     selectedAction,
     setSelectedAction,
-    setDescription,
     actionList,
-    addActionToList,
     removeActionFromList,
     handleOnDragEnd,
   } = useActionList(experienceData,undefined);  // set as undefined to fix ci/cd since we are not using this component anymore

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -140,9 +140,6 @@ function Overlay({ userId, experienceData }: OverlayProps): JSX.Element {
 
             <OverlayGridItem4>
               <TextEditor
-                actionList={actionList}
-                setDescription={(desc) => setDescription(desc)}
-                selectedAction={selectedAction}
               />
             </OverlayGridItem4>
           </OverlayGrid>

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -98,7 +98,7 @@ function Overlay({ userId, experienceData }: OverlayProps): JSX.Element {
     addActionToList,
     removeActionFromList,
     handleOnDragEnd,
-  } = useActionList(experienceData);
+  } = useActionList(experienceData,undefined);  // set as undefined to fix ci/cd since we are not using this component anymore
 
   return experienceData !== undefined ? (
     <OverlayRoot>
@@ -134,7 +134,6 @@ function Overlay({ userId, experienceData }: OverlayProps): JSX.Element {
             <OverlayGridItem3>
               <ActionBox
                 assetBundle={assetBundle}
-                addAction={(actionData) => addActionToList(actionData)}
               />
             </OverlayGridItem3>
 

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 import TextField from "@mui/material/TextField";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { IconButton } from "@mui/material";
 import SaveIcon from "@mui/icons-material/Save";
 import ExpandIcon from "@mui/icons-material/Expand";
 import { ActionData } from "../util/types";
+import { GlobalContext, globalContextTypes } from "../../pages/experience";
 
 const Box = styled.tr`
   background: #3f3d56;
@@ -62,17 +63,12 @@ const TestDiv = styled.div`
 `;
 
 type TextEditorProps = {
-  actionList: ActionData[];
-  selectedAction: number;
   setDescription: (desc) => void;
 };
-const TextEditor = ({
-  actionList,
-  selectedAction,
-  setDescription,
-}: TextEditorProps): JSX.Element => {
+const TextEditor = (): JSX.Element => {
   const [isExpanded, setExpanded] = useState(false);
   const [currDesc, setCurrDesc] = useState("");
+  const {actionList, selectedAction,setDescription} :globalContextTypes= useContext(GlobalContext)
   useEffect(() => {
     if (
       actionList[selectedAction] !== undefined &&

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -4,7 +4,6 @@ import React, { useContext, useEffect, useState } from "react";
 import { IconButton } from "@mui/material";
 import SaveIcon from "@mui/icons-material/Save";
 import ExpandIcon from "@mui/icons-material/Expand";
-import { ActionData } from "../util/types";
 import { GlobalContext, globalContextTypes } from "../../pages/experience";
 
 const Box = styled.tr`
@@ -62,9 +61,6 @@ const TestDiv = styled.div`
   color: white;
 `;
 
-type TextEditorProps = {
-  setDescription: (desc) => void;
-};
 const TextEditor = (): JSX.Element => {
   const [isExpanded, setExpanded] = useState(false);
   const [currDesc, setCurrDesc] = useState("");

--- a/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
+++ b/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
@@ -101,7 +101,7 @@ const {name, setName}=useContext(TestContext)
                           name={
                             name
                           }
-                          removeAction={null}
+                          removeAction={()=>setName("OLD NAME")}
                         />
                 <ActionSequenceItem
                           id={name}

--- a/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
+++ b/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
-import ActionSequenceItem from "./ActionSequenceItem";
 import { useContext } from "react";
+import ActionSequenceItem from "./ActionSequenceItem";
 import {
   GlobalContext,
   globalContextTypes,

--- a/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
+++ b/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
@@ -2,6 +2,8 @@ import styled from "styled-components";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { ActionData } from "../../../util/types";
 import ActionSequenceItem from "./ActionSequenceItem";
+import { useContext } from "react";
+import { TestContext } from "../../../../pages/experience";
 
 const ActionSequenceRoot = styled.div`
   display: relative;
@@ -53,6 +55,11 @@ function ActionSequence({
   handleOnDragEnd,
   removeAction,
 }: ActionSequenceProps): JSX.Element {
+
+
+const {name, setName}=useContext(TestContext)
+
+
   return (
     <ActionSequenceRoot>
       <ActionSequenceHeader />
@@ -89,6 +96,20 @@ function ActionSequence({
                     )}
                   </Draggable>
                 ))}
+                <ActionSequenceItem
+                          id={name}
+                          name={
+                            name
+                          }
+                          removeAction={null}
+                        />
+                <ActionSequenceItem
+                          id={name}
+                          name={
+                            name
+                          }
+                          removeAction={()=>setName("NEW NAME")}
+                        />
                 {dropProvided.placeholder}
               </ActionSequenceList>
             )}

--- a/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
+++ b/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
@@ -1,12 +1,10 @@
 import styled from "styled-components";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
-import { ActionData } from "../../../util/types";
 import ActionSequenceItem from "./ActionSequenceItem";
 import { useContext } from "react";
 import {
   GlobalContext,
   globalContextTypes,
-  TestContext,
 } from "../../../../pages/experience";
 
 const ActionSequenceRoot = styled.div`
@@ -46,7 +44,6 @@ const DragContainer = styled.div`
 `;
 
 function ActionSequence(): JSX.Element {
-  const { name, setName } = useContext(TestContext);
 
   const {
     actionList,
@@ -90,16 +87,6 @@ function ActionSequence(): JSX.Element {
                     )}
                   </Draggable>
                 ))}
-                <ActionSequenceItem
-                  id={name}
-                  name={name}
-                  removeAction={() => setName("OLD NAME")}
-                />
-                <ActionSequenceItem
-                  id={name}
-                  name={name}
-                  removeAction={() => setName("NEW NAME")}
-                />
                 {dropProvided.placeholder}
               </ActionSequenceList>
             )}

--- a/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
+++ b/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
@@ -3,7 +3,11 @@ import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { ActionData } from "../../../util/types";
 import ActionSequenceItem from "./ActionSequenceItem";
 import { useContext } from "react";
-import { TestContext } from "../../../../pages/experience";
+import {
+  GlobalContext,
+  globalContextTypes,
+  TestContext,
+} from "../../../../pages/experience";
 
 const ActionSequenceRoot = styled.div`
   display: relative;
@@ -50,15 +54,14 @@ const DragContainer = styled.div`
   background-color: #3f3d56;
 `;
 
-function ActionSequence({
-  actionList,
-  handleOnDragEnd,
-  removeAction,
-}: ActionSequenceProps): JSX.Element {
+function ActionSequence(): JSX.Element {
+  const { name, setName } = useContext(TestContext);
 
-
-const {name, setName}=useContext(TestContext)
-
+  const {
+    actionList,
+    handleOnDragEnd,
+    removeActionFromList,
+  }: globalContextTypes = useContext(GlobalContext);
 
   return (
     <ActionSequenceRoot>
@@ -90,26 +93,22 @@ const {name, setName}=useContext(TestContext)
                               ? data.input.name
                               : data.input.command
                           }
-                          removeAction={() => removeAction(index)}
+                          removeAction={() => removeActionFromList(index)}
                         />
                       </DragContainer>
                     )}
                   </Draggable>
                 ))}
                 <ActionSequenceItem
-                          id={name}
-                          name={
-                            name
-                          }
-                          removeAction={()=>setName("OLD NAME")}
-                        />
+                  id={name}
+                  name={name}
+                  removeAction={() => setName("OLD NAME")}
+                />
                 <ActionSequenceItem
-                          id={name}
-                          name={
-                            name
-                          }
-                          removeAction={()=>setName("NEW NAME")}
-                        />
+                  id={name}
+                  name={name}
+                  removeAction={() => setName("NEW NAME")}
+                />
                 {dropProvided.placeholder}
               </ActionSequenceList>
             )}

--- a/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
+++ b/src/components/UIComponent/Action Sequence 2.0/ActionSequence.tsx
@@ -38,15 +38,6 @@ const ActionSequenceList = styled.div`
   }
 `;
 
-type ActionSequenceProps = {
-  actionList: ActionData[];
-  removeAction: (index: number) => void;
-  handleOnDragEnd: (result: {
-    destination: { index: number };
-    source: { index: number };
-  }) => void;
-};
-
 const DragContainer = styled.div`
   border: 1px solid black;
   max-height: 85%;

--- a/src/components/UIComponent/ApparatusInfo.tsx
+++ b/src/components/UIComponent/ApparatusInfo.tsx
@@ -1,18 +1,12 @@
 import { useContext, useState } from "react";
-import { ActionData, SerializedApparatus } from "../../util/types";
+import { SerializedApparatus } from "../../util/types";
 import ApparatusListBox from "../editorBoxes/ApparatusListBox";
 import ActionBox from "../editorBoxes/ActionBox";
 import { GlobalContext, globalContextTypes } from "../../../pages/experience";
 
-type OverlayProps = {
-  addActionToList: (actionData: ActionData) => void;
-  removeActionFromList : (index: number) => void;
-};
-
-
 function ApparatusInfo(): JSX.Element {
-
-  const {experienceData,addActionToList} :globalContextTypes= useContext(GlobalContext)
+  const { experienceData, addActionToList }: globalContextTypes =
+    useContext(GlobalContext);
 
   const [assetBundle, setAssetBundle] = useState({
     children: [],
@@ -21,21 +15,18 @@ function ApparatusInfo(): JSX.Element {
   });
   return (
     <>
-      <ApparatusListBox                                         
+      <ApparatusListBox
         metadata={checkIfMetaExists()}
         handleAssetBundleChange={(data) => setAssetBundle(data)}
       />
       <ActionBox
         assetBundle={assetBundle}
-        addAction={(actionData) =>
-          addActionToList(actionData)
-        }
+        addAction={(actionData) => addActionToList(actionData)}
       />
     </>
   );
 
   function checkIfMetaExists(): SerializedApparatus {
-
     return experienceData !== undefined
       ? experienceData.apparatusMetadata
       : undefined;

--- a/src/components/UIComponent/ApparatusInfo.tsx
+++ b/src/components/UIComponent/ApparatusInfo.tsx
@@ -1,17 +1,20 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { ActionData, ExperienceData, SerializedApparatus } from "../../util/types";
 import ApparatusListBox from "../editorBoxes/ApparatusListBox";
 import ActionBox from "../editorBoxes/ActionBox";
+import { GlobalContext, globalContextTypes } from "../../../pages/experience";
 
 type OverlayProps = {
-  experienceData: ExperienceData;
   addActionToList: (actionData: ActionData) => void;
   removeActionFromList : (index: number) => void;
 
 };
 
 
-function ApparatusInfo({experienceData,addActionToList, removeActionFromList}: OverlayProps): JSX.Element {
+function ApparatusInfo({addActionToList, removeActionFromList}: OverlayProps): JSX.Element {
+
+  const {experienceData} :globalContextTypes= useContext(GlobalContext)
+
   const [assetBundle, setAssetBundle] = useState({
     children: [],
     path: "",
@@ -19,7 +22,7 @@ function ApparatusInfo({experienceData,addActionToList, removeActionFromList}: O
   });
   return (
     <>
-      <ApparatusListBox
+      <ApparatusListBox                                                         // metadata not taking from experience data
         metadata={checkIfMetaExists()}
         handleAssetBundleChange={(data) => setAssetBundle(data)}
       />
@@ -33,6 +36,7 @@ function ApparatusInfo({experienceData,addActionToList, removeActionFromList}: O
   );
 
   function checkIfMetaExists(): SerializedApparatus {
+
     return experienceData !== undefined
       ? experienceData.apparatusMetadata
       : undefined;

--- a/src/components/UIComponent/ApparatusInfo.tsx
+++ b/src/components/UIComponent/ApparatusInfo.tsx
@@ -1,5 +1,5 @@
 import { useContext, useState } from "react";
-import { ActionData, ExperienceData, SerializedApparatus } from "../../util/types";
+import { ActionData, SerializedApparatus } from "../../util/types";
 import ApparatusListBox from "../editorBoxes/ApparatusListBox";
 import ActionBox from "../editorBoxes/ActionBox";
 import { GlobalContext, globalContextTypes } from "../../../pages/experience";
@@ -7,7 +7,6 @@ import { GlobalContext, globalContextTypes } from "../../../pages/experience";
 type OverlayProps = {
   addActionToList: (actionData: ActionData) => void;
   removeActionFromList : (index: number) => void;
-
 };
 
 
@@ -22,7 +21,7 @@ function ApparatusInfo({addActionToList, removeActionFromList}: OverlayProps): J
   });
   return (
     <>
-      <ApparatusListBox                                                         // metadata not taking from experience data
+      <ApparatusListBox                                         
         metadata={checkIfMetaExists()}
         handleAssetBundleChange={(data) => setAssetBundle(data)}
       />

--- a/src/components/UIComponent/ApparatusInfo.tsx
+++ b/src/components/UIComponent/ApparatusInfo.tsx
@@ -10,9 +10,9 @@ type OverlayProps = {
 };
 
 
-function ApparatusInfo({addActionToList, removeActionFromList}: OverlayProps): JSX.Element {
+function ApparatusInfo(): JSX.Element {
 
-  const {experienceData} :globalContextTypes= useContext(GlobalContext)
+  const {experienceData,addActionToList} :globalContextTypes= useContext(GlobalContext)
 
   const [assetBundle, setAssetBundle] = useState({
     children: [],

--- a/src/components/UIComponent/ApparatusInfo.tsx
+++ b/src/components/UIComponent/ApparatusInfo.tsx
@@ -5,7 +5,7 @@ import ActionBox from "../editorBoxes/ActionBox";
 import { GlobalContext, globalContextTypes } from "../../../pages/experience";
 
 function ApparatusInfo(): JSX.Element {
-  const { experienceData, addActionToList }: globalContextTypes =
+  const { experienceData }: globalContextTypes =
     useContext(GlobalContext);
 
   const [assetBundle, setAssetBundle] = useState({
@@ -21,7 +21,6 @@ function ApparatusInfo(): JSX.Element {
       />
       <ActionBox
         assetBundle={assetBundle}
-        addAction={(actionData) => addActionToList(actionData)}
       />
     </>
   );

--- a/src/components/UIComponent/Overlay2.tsx
+++ b/src/components/UIComponent/Overlay2.tsx
@@ -7,6 +7,8 @@ import ToolDocItem from "./ToolDocItem";
 import { ExperienceData } from "../../util/types";
 import { useActionList } from "../../util/customHooks/overlayfunc";
 import TextEditor from "../TextEditor";
+import { GlobalContext, globalContextTypes } from "../../../pages/experience";
+import { useContext } from "react";
 
 // the side bar box
 
@@ -61,14 +63,18 @@ const TextEditorGrid = styled.div`
 
 type OverlayProps = {
   userId: string;
-  experienceData: ExperienceData;
 };
 
 /**
  * The side bar define the area and the outline of what will be included.
  * @returns
  */
-function Overlay2({ userId, experienceData }: OverlayProps): JSX.Element {
+function Overlay2({ userId }: OverlayProps): JSX.Element {
+
+
+  // potentially unneeded use once actionlist is made a global variable
+  const {experienceData} :globalContextTypes= useContext(GlobalContext)
+
   const {
     toggleToolDoc,
     toggleApparatusInfo,
@@ -114,7 +120,7 @@ function Overlay2({ userId, experienceData }: OverlayProps): JSX.Element {
             </SideBarGrid>
             {toolDoc ? (
               <ToolDocGrid>
-                <ToolDocItem experienceData={experienceData} addActionToList={(actionData) => addActionToList(actionData)}  removeAction={(index: number) => removeActionFromList(index)} />
+                <ToolDocItem addActionToList={(actionData) => addActionToList(actionData)}  removeAction={(index: number) => removeActionFromList(index)} />
               </ToolDocGrid>
             ) : (
               <div />

--- a/src/components/UIComponent/Overlay2.tsx
+++ b/src/components/UIComponent/Overlay2.tsx
@@ -4,10 +4,7 @@ import SideBarItem from "./SideBarItem";
 import ActionSequence from "./Action Sequence 2.0/ActionSequence";
 import { SideBarContext } from "../../util/customHooks/SideBarContext";
 import ToolDocItem from "./ToolDocItem";
-import { useActionList } from "../../util/customHooks/overlayfunc";
 import TextEditor from "../TextEditor";
-import { GlobalContext, globalContextTypes } from "../../../pages/experience";
-import { useContext } from "react";
 
 // the side bar box
 
@@ -60,15 +57,11 @@ const TextEditorGrid = styled.div`
   z-index: 2;
 `;
 
-type OverlayProps = {
-  userId: string;
-};
-
 /**
  * The side bar define the area and the outline of what will be included.
  * @returns
  */
-function Overlay2({ userId }: OverlayProps): JSX.Element {
+function Overlay2(): JSX.Element {
 
   const {
     toggleToolDoc,
@@ -99,7 +92,7 @@ function Overlay2({ userId }: OverlayProps): JSX.Element {
           }}
         >
           <SideBarGrid>
-            <SideBarItem userId={userId} />
+            <SideBarItem/>
           </SideBarGrid>
           {toolDoc ? (
             <ToolDocGrid>

--- a/src/components/UIComponent/Overlay2.tsx
+++ b/src/components/UIComponent/Overlay2.tsx
@@ -69,10 +69,8 @@ type OverlayProps = {
  * @returns
  */
 function Overlay2({ userId }: OverlayProps): JSX.Element {
-
-
   // potentially unneeded use once actionlist is made a global variable
-  const {experienceData} :globalContextTypes= useContext(GlobalContext)
+  const { experienceData }: globalContextTypes = useContext(GlobalContext);
 
   const {
     toggleToolDoc,
@@ -87,15 +85,14 @@ function Overlay2({ userId }: OverlayProps): JSX.Element {
   } = useActionBar();
 
   // Things Justin needs to use in action sequence, fix the variable names so I can use them please
-  const {
-    selectedAction,
-    actionList,
-    removeActionFromList,
-    setDescription,
-    handleOnDragEnd,
-    addActionToList,
-  } = useActionList(experienceData);
-
+  // const {
+  //   selectedAction,
+  //   actionList,
+  //   removeActionFromList,
+  //   setDescription,
+  //   handleOnDragEnd,
+  //   addActionToList,
+  // } = useActionList(experienceData);
 
   return (
     <UIComponentRoot>
@@ -113,33 +110,23 @@ function Overlay2({ userId }: OverlayProps): JSX.Element {
             setSkyBoxInfo,
           }}
         >
-
-            <SideBarGrid>
-              <SideBarItem userId={userId}/>
-            </SideBarGrid>
-            {toolDoc ? (
-              <ToolDocGrid>
-                <ToolDocItem  addActionToList={(actionData) => addActionToList(actionData)}  removeAction={(index: number) => removeActionFromList(index)} />
-              </ToolDocGrid>
-            ) : (
-              <div />
-            )}
-
+          <SideBarGrid>
+            <SideBarItem userId={userId} />
+          </SideBarGrid>
+          {toolDoc ? (
+            <ToolDocGrid>
+              <ToolDocItem />
+            </ToolDocGrid>
+          ) : (
+            <div />
+          )}
         </SideBarContext.Provider>
         <ActionSequenceBarGrid>
-          <ActionSequence
-            actionList={actionList}
-            removeAction={(index: number) => removeActionFromList(index)}
-            handleOnDragEnd={handleOnDragEnd}
-          />
+          <ActionSequence />
         </ActionSequenceBarGrid>
         <TextEditorGrid>
           {" "}
-          <TextEditor
-            actionList={actionList}
-            setDescription={(desc) => setDescription(desc)}
-            selectedAction={selectedAction}
-          />
+          <TextEditor />
         </TextEditorGrid>
 
         {/* <TextEditorGrid /> */}
@@ -149,4 +136,3 @@ function Overlay2({ userId }: OverlayProps): JSX.Element {
 }
 
 export default Overlay2;
-

--- a/src/components/UIComponent/Overlay2.tsx
+++ b/src/components/UIComponent/Overlay2.tsx
@@ -4,7 +4,6 @@ import SideBarItem from "./SideBarItem";
 import ActionSequence from "./Action Sequence 2.0/ActionSequence";
 import { SideBarContext } from "../../util/customHooks/SideBarContext";
 import ToolDocItem from "./ToolDocItem";
-import { ExperienceData } from "../../util/types";
 import { useActionList } from "../../util/customHooks/overlayfunc";
 import TextEditor from "../TextEditor";
 import { GlobalContext, globalContextTypes } from "../../../pages/experience";
@@ -116,11 +115,11 @@ function Overlay2({ userId }: OverlayProps): JSX.Element {
         >
 
             <SideBarGrid>
-              <SideBarItem userId={userId} experienceData={experienceData} />
+              <SideBarItem userId={userId}/>
             </SideBarGrid>
             {toolDoc ? (
               <ToolDocGrid>
-                <ToolDocItem addActionToList={(actionData) => addActionToList(actionData)}  removeAction={(index: number) => removeActionFromList(index)} />
+                <ToolDocItem  addActionToList={(actionData) => addActionToList(actionData)}  removeAction={(index: number) => removeActionFromList(index)} />
               </ToolDocGrid>
             ) : (
               <div />

--- a/src/components/UIComponent/Overlay2.tsx
+++ b/src/components/UIComponent/Overlay2.tsx
@@ -69,8 +69,6 @@ type OverlayProps = {
  * @returns
  */
 function Overlay2({ userId }: OverlayProps): JSX.Element {
-  // potentially unneeded use once actionlist is made a global variable
-  const { experienceData }: globalContextTypes = useContext(GlobalContext);
 
   const {
     toggleToolDoc,
@@ -83,16 +81,6 @@ function Overlay2({ userId }: OverlayProps): JSX.Element {
     setApparatusInfo,
     setSkyBoxInfo,
   } = useActionBar();
-
-  // Things Justin needs to use in action sequence, fix the variable names so I can use them please
-  // const {
-  //   selectedAction,
-  //   actionList,
-  //   removeActionFromList,
-  //   setDescription,
-  //   handleOnDragEnd,
-  //   addActionToList,
-  // } = useActionList(experienceData);
 
   return (
     <UIComponentRoot>
@@ -128,8 +116,6 @@ function Overlay2({ userId }: OverlayProps): JSX.Element {
           {" "}
           <TextEditor />
         </TextEditorGrid>
-
-        {/* <TextEditorGrid /> */}
       </UIComponentGrid>
     </UIComponentRoot>
   );

--- a/src/components/UIComponent/SideBarItem.tsx
+++ b/src/components/UIComponent/SideBarItem.tsx
@@ -42,12 +42,10 @@ const ImgLogo = styled.img.attrs({
   margin-left: auto;
   margin-right: auto;
 `;
-type OverlayProps = {
-  userId: string;
-};
-function SideBarItem({ userId }: OverlayProps): JSX.Element {
+
+function SideBarItem(): JSX.Element {
   const { toggleApparatusInfo, toggleSkyBoxInfo } = useContext(SideBarContext);
-  const { experienceData }: globalContextTypes = useContext(GlobalContext);
+  const { experienceData, userId }: globalContextTypes = useContext(GlobalContext);
   const { actionList } = useActionList(experienceData);
 
   return (

--- a/src/components/UIComponent/SideBarItem.tsx
+++ b/src/components/UIComponent/SideBarItem.tsx
@@ -45,8 +45,8 @@ const ImgLogo = styled.img.attrs({
 
 function SideBarItem(): JSX.Element {
   const { toggleApparatusInfo, toggleSkyBoxInfo } = useContext(SideBarContext);
-  const { experienceData, userId }: globalContextTypes = useContext(GlobalContext);
-  const { actionList } = useActionList(experienceData);
+  const { experienceData, userId , setExperienceData }: globalContextTypes = useContext(GlobalContext);
+  const { actionList } = useActionList(experienceData,setExperienceData);
 
   return (
     <>

--- a/src/components/UIComponent/SideBarItem.tsx
+++ b/src/components/UIComponent/SideBarItem.tsx
@@ -45,18 +45,17 @@ const ImgLogo = styled.img.attrs({
 type OverlayProps = {
   userId: string;
 };
-function SideBarItem({userId}: OverlayProps): JSX.Element {
+function SideBarItem({ userId }: OverlayProps): JSX.Element {
   const { toggleApparatusInfo, toggleSkyBoxInfo } = useContext(SideBarContext);
-  const {experienceData} :globalContextTypes= useContext(GlobalContext)
+  const { experienceData }: globalContextTypes = useContext(GlobalContext);
   const { actionList } = useActionList(experienceData);
-
 
   return (
     <>
       <SideBarItemBox>
         <Link href="/">
           {" "}
-          <ImgLogo src={urlFor("assets/epistaLogo.png")}/>
+          <ImgLogo src={urlFor("assets/epistaLogo.png")} />
         </Link>
 
         <SideBarItemWrapper>

--- a/src/components/UIComponent/SideBarItem.tsx
+++ b/src/components/UIComponent/SideBarItem.tsx
@@ -8,8 +8,8 @@ import KeyboardReturnIcon from "@mui/icons-material/KeyboardReturn";
 import { SideBarContext } from "../../util/customHooks/SideBarContext";
 import { saveExp } from "../../util/cloudOperations/writeToCloud";
 import { useActionList } from "../../util/customHooks/overlayfunc";
-import { ExperienceData } from "../../util/types";
 import { urlFor } from "../../util/utils";
+import { GlobalContext, globalContextTypes } from "../../../pages/experience";
 
 const SideBarItemBox = styled.div`
   position: flex;
@@ -44,11 +44,12 @@ const ImgLogo = styled.img.attrs({
 `;
 type OverlayProps = {
   userId: string;
-  experienceData: ExperienceData;
 };
-function SideBarItem({userId, experienceData}: OverlayProps): JSX.Element {
+function SideBarItem({userId}: OverlayProps): JSX.Element {
   const { toggleApparatusInfo, toggleSkyBoxInfo } = useContext(SideBarContext);
+  const {experienceData} :globalContextTypes= useContext(GlobalContext)
   const { actionList } = useActionList(experienceData);
+
 
   return (
     <>

--- a/src/components/UIComponent/ToolDocItem.tsx
+++ b/src/components/UIComponent/ToolDocItem.tsx
@@ -5,13 +5,11 @@ import ApparatusInfo from "./ApparatusInfo";
 import SkyBoxInfo from "./SkyBoxInfo";
 
 type ToolDocItemProps = {
-  experienceData: ExperienceData;
   addActionToList: (actionData: ActionData) => void;
   removeAction: (index: number) => void;
 };
 
 function ToolDocItem({
-  experienceData,
   addActionToList, removeAction
 }: ToolDocItemProps): JSX.Element {
   const { apparatusInfo, skyboxInfo } = useContext(SideBarContext);
@@ -19,7 +17,6 @@ function ToolDocItem({
     <div>
       {apparatusInfo ? (
         <ApparatusInfo
-          experienceData={experienceData}
           addActionToList={addActionToList}
           removeActionFromList = {removeAction}
         />

--- a/src/components/UIComponent/ToolDocItem.tsx
+++ b/src/components/UIComponent/ToolDocItem.tsx
@@ -9,17 +9,12 @@ type ToolDocItemProps = {
   removeAction: (index: number) => void;
 };
 
-function ToolDocItem({
-  addActionToList, removeAction
-}: ToolDocItemProps): JSX.Element {
+function ToolDocItem(): JSX.Element {
   const { apparatusInfo, skyboxInfo } = useContext(SideBarContext);
   return (
     <div>
       {apparatusInfo ? (
-        <ApparatusInfo
-          addActionToList={addActionToList}
-          removeActionFromList = {removeAction}
-        />
+        <ApparatusInfo/>
       ) : (
         <div />
       )}

--- a/src/components/UIComponent/ToolDocItem.tsx
+++ b/src/components/UIComponent/ToolDocItem.tsx
@@ -1,23 +1,13 @@
 import { useContext } from "react";
 import { SideBarContext } from "../../util/customHooks/SideBarContext";
-import { ActionData} from "../../util/types";
 import ApparatusInfo from "./ApparatusInfo";
 import SkyBoxInfo from "./SkyBoxInfo";
-
-type ToolDocItemProps = {
-  addActionToList: (actionData: ActionData) => void;
-  removeAction: (index: number) => void;
-};
 
 function ToolDocItem(): JSX.Element {
   const { apparatusInfo, skyboxInfo } = useContext(SideBarContext);
   return (
     <div>
-      {apparatusInfo ? (
-        <ApparatusInfo/>
-      ) : (
-        <div />
-      )}
+      {apparatusInfo ? <ApparatusInfo /> : <div />}
       {skyboxInfo ? <SkyBoxInfo /> : <div />}
     </div>
   );

--- a/src/components/UIComponent/ToolDocItem.tsx
+++ b/src/components/UIComponent/ToolDocItem.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { SideBarContext } from "../../util/customHooks/SideBarContext";
-import { ActionData, ExperienceData } from "../../util/types";
+import { ActionData} from "../../util/types";
 import ApparatusInfo from "./ApparatusInfo";
 import SkyBoxInfo from "./SkyBoxInfo";
 

--- a/src/components/WebglBox.tsx
+++ b/src/components/WebglBox.tsx
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 import Unity from "react-unity-webgl";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import Loading from "./Loading";
 import { unityContext, loadApparatus } from "../util/unityContextActions";
 import { ExperienceData } from "../util/types";
 import Overlay2 from "./UIComponent/Overlay2";
+import { GlobalContext, globalContextTypes } from "../../pages/experience";
 
 const WebglRoot = styled.div`
   display: relative;
@@ -14,10 +15,13 @@ const WebglRoot = styled.div`
 
 type WebglProps = {
   userId: string;
-  experienceData: ExperienceData;
 };
 
-function WebglBox({ userId, experienceData }: WebglProps): JSX.Element {
+function WebglBox({ userId }: WebglProps): JSX.Element {
+
+
+  const {experienceData} :globalContextTypes= useContext(GlobalContext)
+
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     if (window["onAtomataSceneInitalize"] === undefined) {

--- a/src/components/WebglBox.tsx
+++ b/src/components/WebglBox.tsx
@@ -3,7 +3,6 @@ import Unity from "react-unity-webgl";
 import { useContext, useEffect, useState } from "react";
 import Loading from "./Loading";
 import { unityContext, loadApparatus } from "../util/unityContextActions";
-import { ExperienceData } from "../util/types";
 import Overlay2 from "./UIComponent/Overlay2";
 import { GlobalContext, globalContextTypes } from "../../pages/experience";
 
@@ -49,7 +48,7 @@ function WebglBox({ userId }: WebglProps): JSX.Element {
         }}
         tabIndex={1}
       />
-      <Overlay2 userId={userId} experienceData={experienceData} />
+      <Overlay2 userId={userId} />
       {/* <Overlay userId={userId} experienceData={experienceData} /> */}
     </WebglRoot>
   ) : (

--- a/src/components/WebglBox.tsx
+++ b/src/components/WebglBox.tsx
@@ -48,8 +48,7 @@ function WebglBox({ userId }: WebglProps): JSX.Element {
         }}
         tabIndex={1}
       />
-      <Overlay2 userId={userId} />
-      {/* <Overlay userId={userId} experienceData={experienceData} /> */}
+      <Overlay2 />
     </WebglRoot>
   ) : (
     <WebglRoot>

--- a/src/components/WebglBox.tsx
+++ b/src/components/WebglBox.tsx
@@ -12,14 +12,8 @@ const WebglRoot = styled.div`
   height: 100%;
 `;
 
-type WebglProps = {
-  userId: string;
-};
-
-function WebglBox({ userId }: WebglProps): JSX.Element {
-
-
-  const {experienceData} :globalContextTypes= useContext(GlobalContext)
+function WebglBox(): JSX.Element {
+  const { experienceData }: globalContextTypes = useContext(GlobalContext);
 
   const [loading, setLoading] = useState(true);
   useEffect(() => {

--- a/src/components/editorBoxes/ActionBox.tsx
+++ b/src/components/editorBoxes/ActionBox.tsx
@@ -8,9 +8,11 @@ import {
   ListItemSecondaryAction,
 } from "@mui/material";
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
+import { useContext } from "react";
 import { requestTrigger } from "../../util/unityContextActions";
 import { getActions } from "../../util/jsonParsing";
-import { ActionData, AssetBundle } from "../../util/types";
+import { AssetBundle } from "../../util/types";
+import { GlobalContext, globalContextTypes } from "../../../pages/experience";
 
 const Box = styled.div`
   background: #fffaf0;
@@ -42,14 +44,15 @@ const ListHeading = styled.h1`
 
 type ActionBoxProps = {
   assetBundle: AssetBundle;
-  addAction: (actionData: ActionData) => void;
 };
 
-const ActionBox = ({ assetBundle, addAction }: ActionBoxProps): JSX.Element => {
+const ActionBox = ({ assetBundle }: ActionBoxProps): JSX.Element => {
   const actionList = React.useMemo(
     () => getActions(assetBundle),
     [assetBundle]
   );
+
+  const { addActionToList }: globalContextTypes = useContext(GlobalContext);
 
   // everytime metadata is rendered we reparse metadata using useMemo hook
   if (actionList !== undefined && actionList[0] !== undefined)
@@ -91,7 +94,7 @@ const ActionBox = ({ assetBundle, addAction }: ActionBoxProps): JSX.Element => {
                       assetId: actionData.assetId,
                       desc: actionData.desc,
                     };
-                    addAction(actionDataClone);
+                    addActionToList(actionDataClone);
                   }}
                 >
                   <AddOutlinedIcon />
@@ -110,5 +113,3 @@ const ActionBox = ({ assetBundle, addAction }: ActionBoxProps): JSX.Element => {
   );
 };
 export default ActionBox;
-
-// fixed

--- a/src/util/customHooks/overlayfunc.tsx
+++ b/src/util/customHooks/overlayfunc.tsx
@@ -1,13 +1,28 @@
-import { useState } from "react";
+import { Dispatch, SetStateAction, useMemo, useState } from "react";
 import { ActionData, ExperienceData } from "../types";
 
 /*
  *custom hook for overlay, action list
  */
 
-const useActionList = (experienceData: ExperienceData) => {
-  const [actionList, setActionList] = useState(
-    experienceData !== undefined ? experienceData.experience.actionList : []
+const useActionList = (
+  experienceData: ExperienceData,
+  setExperienceData: Dispatch<SetStateAction<ExperienceData>>
+) => {
+  // const [actionList, setActionList] = useState(
+  //   experienceData !== undefined ? experienceData.experience.actionList : []
+  // );
+
+  const [actionList, setActionList] = useMemo(
+    () => [
+      experienceData?.experience?.actionList ?? [],
+      (list: ActionData[]) =>
+        setExperienceData((e) => ({
+          ...e,
+          experience: { ...e?.experience, actionList: list },
+        })),
+    ],
+    [experienceData, setExperienceData]
   );
 
   const [selectedAction, setSelectedAction] = useState(0);


### PR DESCRIPTION
### Summary 
Refactoring of Certain Hooks into Global Context Hooks in order to avoid Props drilling
### Details
This PR adds Global Context Hooks in a high level component (namely experience.tsx), and the following hooks and their sub-hooks have been refactored to be used as Global Context Hooks
1. experienceData
2. actionList
3. userId

### How to test?
1. Spin up the app and make sure the editor successfully passes data back and forth. 
2. The app should work exactly like the current main branch.

### Checks 
- [ ] Tested Changes
- [ ] Stakeholder Approval
